### PR TITLE
Bump androidx.compose:compose-bom from 2026.05.01 to 2026.06.00

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,7 +88,7 @@ dependencies {
     implementation("com.github.doyaaaaaken:kotlin-csv-jvm:1.10.0")
 
     // Compose
-    implementation(platform("androidx.compose:compose-bom:2026.05.01"))
+    implementation(platform("androidx.compose:compose-bom:2026.06.00"))
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.compose.ui:ui-tooling-preview")


### PR DESCRIPTION
Bumps androidx.compose:compose-bom from 2026.05.01 to 2026.06.00.

---
updated-dependencies:
- dependency-name: androidx.compose:compose-bom dependency-version: 2026.06.00 dependency-type: direct:production ...